### PR TITLE
organization updates

### DIFF
--- a/templates/boomi-molecule-master.template.yaml
+++ b/templates/boomi-molecule-master.template.yaml
@@ -27,17 +27,14 @@ Metadata:
           default: "Dell Boomi Molecule Configuration"
         Parameters:
           - MoleculeInstanceName
+          - HeadMoleculeInstanceType
+          - InstanceType
           - MoleculeLocalPath
           - MoleculeLocalTemp
           - BoomiAccountID
           - BoomiUsername
           - BoomiPassword
           - MoleculeSharedDir
-      - Label:
-         default: "AWS Quick Start configuration"
-        Parameters:
-         - QSS3KeyPrefix
-         - QSS3BucketName
       - Label:
           default: "Amazon EFS Configuration"
         Parameters:
@@ -51,6 +48,11 @@ Metadata:
           - MoleculeFQDN
           - HostedZoneID
           - SSLCertificateArn
+      - Label:
+         default: "AWS Quick Start Configuration"
+        Parameters:
+         - QSS3KeyPrefix
+         - QSS3BucketName
     ParameterLabels:
       KeyPairName:
         default: SSH key name


### PR DESCRIPTION
Moved HeadMoleculeInstanceType and InstanceType into the Dell Boomi Molecule Configuration category; moved the Quick Start Configuration category to the end, according to the guidelines.

*Issue #, if available:* Two parameters were not categorized; Quick Starts category was not in the right place.

*Description of changes:* Added the parameters to a category (please confirm that the placement is accurate) and moved the Quick Starts category.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
