### PR TITLE
Boomi recommended mount option "noatime"

### DIFF
--- a/templates/boomi-molecule.template.yaml
+++ b/templates/boomi-molecule.template.yaml
@@ -431,7 +431,7 @@ Resources:
                   efs_IP=$(dig +short ${!CURRENT_AZ}.${FilesystemID}.efs.${AWS::Region}.amazonaws.com @${!zone_dns})
                   if [ -z ${!efs_IP} ]; then exit 1; fi
                   echo "${!efs_IP} ${!CURRENT_AZ}.${FilesystemID}.efs.${AWS::Region}.amazonaws.com" >> /etc/hosts
-                  echo "${!CURRENT_AZ}.${FilesystemID}.efs.${AWS::Region}.amazonaws.com:/ ${MoleculeSharedDir} nfs4 defaults,vers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0" >> /etc/fstab
+                  echo "${!CURRENT_AZ}.${FilesystemID}.efs.${AWS::Region}.amazonaws.com:/ ${MoleculeSharedDir} nfs4 defaults,vers=4.1,rsize=1048576,wsize=1048576,hard,noatime 0 0" >> /etc/fstab
                   mount -a
                 - FilesystemID:
                     !If


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Took out timeo and retrans which are not recommended, added noatime which is recommended (important for performance).
Doc link:
https://help.boomi.com/bundle/integration/page/int-Molecule_installation_checklist_Linux.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
